### PR TITLE
add "expect" command to dev container

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,15 +1,16 @@
 FROM gsol/node:6.9.1
 MAINTAINER Global Solutions co., ltd.
-LABEL version="0.4.1"
+LABEL version="0.5.0"
 
 ENV NODE_USER=node
 WORKDIR "/home/${NODE_USER}/app"
 
 # git for @kadira/react-storybook
 # libelf-dev, libelf1 for flow-bin
+# expect for npm login
 RUN adduser --disabled-login ${NODE_USER} && \
     chown ${NODE_USER}:${NODE_USER} .. -R && \
-    deps="git ca-certificates libelf-dev libelf1" && \
+    deps="git ca-certificates libelf-dev libelf1 expect" && \
     apt-get update && apt-get install --no-install-recommends -y $deps && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What

add "expect" command to dev container. "expect" talks to other interacitve programs.

## Why

to run "npm login & npm publish" in the docker container