### PR TITLE
Bump/node 8.9.0

### DIFF
--- a/dev-debian/Dockerfile
+++ b/dev-debian/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:6.11.3
+FROM node:8.9.0
 MAINTAINER Global Solutions co., ltd.
-LABEL version="1.1.1"
+LABEL version="1.2.0"
 
 ENV NODE_USER=node
 WORKDIR "/home/${NODE_USER}/app"

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,16 +1,23 @@
-FROM gsol/node:6.11.3-flow
+FROM node:6.11.3-alpine
 MAINTAINER Global Solutions co., ltd.
-LABEL version="2.1.1"
+LABEL version="2.2.0"
 
+ENV GLIBC_VERSION=2.26-r0
 ENV NODE_USER=node
 WORKDIR "/home/${NODE_USER}/app"
 
 # git for @kadira/react-storybook
 # findutils for xargs and find
+# glibc for flow
 RUN chown ${NODE_USER}:${NODE_USER} .. -R && \
     deps="git ca-certificates patch findutils" && \
     apk add --no-cache $deps && \
-    rm -rf /var/lib/apt/lists/*
+    apk --no-cache add --virtual .build-deps wget && \
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
+    apk add glibc-${GLIBC_VERSION}.apk && \
+    apk del .build-deps && \
+    rm -rf /var/lib/apt/lists/* glibc-${GLIBC_VERSION}.apk /etc/apk/keys/sgerrand.rsa.pub
 
 USER ${NODE_USER}
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.11.3-alpine
+FROM node:8.9.0-alpine
 MAINTAINER Global Solutions co., ltd.
 LABEL version="2.2.0"
 


### PR DESCRIPTION
* node: v6.11.3 ▶️ v8.9.0
* additional changes
    * flow container: deprecated (no longer in use)
   * dev container:
        * add git, ca-certificates, patch, findutils and glibc
        * replace a base container (prebuilt flow container ▶️ offical alpine container)
    * dev-debian container: add git, ca-certificates, patch and findutils
