### PR TITLE
Bump/node 8.11.2

### DIFF
--- a/dev-debian/Dockerfile
+++ b/dev-debian/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:8.11.0
+FROM node:8.11.2
 MAINTAINER Global Solutions co., ltd.
-LABEL version="1.4.0"
+LABEL version="1.4.1"
 
 ENV NODE_USER=node
 WORKDIR "/home/${NODE_USER}/app"

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:8.11.0-alpine
+FROM node:8.11.2-alpine
 MAINTAINER Global Solutions co., ltd.
-LABEL version="2.4.0"
+LABEL version="2.4.1"
 
 ENV GLIBC_VERSION=2.27-r0
 ENV NODE_USER=node


### PR DESCRIPTION
* node: v8.11.0 ▶️ v8.11.2
* additional changes
   * dev container(alpine base):
        * add git, ca-certificates, patch, findutils, wget and glibc(2.27-r0)
    * dev-debian container: add git, ca-certificates, patch and findutils